### PR TITLE
fix: Fix langchain imports

### DIFF
--- a/chains/formalize.py
+++ b/chains/formalize.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any, Optional
-from langchain import BasePromptTemplate, PromptTemplate
+from langchain.prompts import BasePromptTemplate, PromptTemplate
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
 from langchain.text_splitter import CharacterTextSplitter

--- a/chains/headline.py
+++ b/chains/headline.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any, Optional
-from langchain import BasePromptTemplate, PromptTemplate
+from langchain.prompts import BasePromptTemplate, PromptTemplate
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
 from langchain.text_splitter import CharacterTextSplitter

--- a/chains/simplify.py
+++ b/chains/simplify.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any, Optional
-from langchain import BasePromptTemplate, PromptTemplate
+from langchain.prompts import BasePromptTemplate, PromptTemplate
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
 from langchain.text_splitter import CharacterTextSplitter

--- a/chains/summarize.py
+++ b/chains/summarize.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any, Optional
-from langchain import BasePromptTemplate, PromptTemplate
+from langchain.prompts import BasePromptTemplate, PromptTemplate
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
 from langchain.text_splitter import CharacterTextSplitter

--- a/chains/topics.py
+++ b/chains/topics.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Any, Optional
-from langchain import BasePromptTemplate, PromptTemplate
+from langchain.prompts import BasePromptTemplate, PromptTemplate
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import CallbackManagerForChainRun
 from langchain.text_splitter import CharacterTextSplitter


### PR DESCRIPTION
Fixes `UserWarning: Importing BasePromptTemplate from langchain root module is no longer supported. Please use langchain.schema.prompt_template.BasePromptTemplate instead`